### PR TITLE
updates path `root` for endpoint /wp-content/uploads/

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -78,7 +78,7 @@ web:
             scripts: false
             allow: false
         "/wp-content/uploads":
-            root: "wp-content/uploads"
+            root: "web/wp-content/uploads"
             scripts: false
             allow: false
             rules:


### PR DESCRIPTION
Fixes #2 
Updates path for `root` for endpoint /wp-content/uploads