### PR TITLE
Fix path in wp-cli.yml

### DIFF
--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,2 +1,2 @@
-path: /app/web/
+path: web
 color: true


### PR DESCRIPTION
This fixes WP path in `wp-cli.yml` to use a relative path to the `web` directory.
As a result, one must use `wp` commands from root (not from web, or by using `--path` option).
