### PR TITLE
Fix WordPress database error because of post_clauses hook

### DIFF
--- a/.muplugins/blackfire.php
+++ b/.muplugins/blackfire.php
@@ -64,7 +64,6 @@ class Blackfire_Markers
         yield 'wp_loaded';
         yield 'parse_request';
         yield 'parse_query';
-        yield 'posts_clauses';
         yield 'posts_selection';
         yield 'wp';
         yield 'template_redirect';


### PR DESCRIPTION
Hooking  into `posts_clauses` caused the following error:

```
WordPress database error: [You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'FROM wp_posts WHERE 1=1' at line 1]
SELECT FROM wp_posts WHERE 1=1 
```
